### PR TITLE
Include logic to help debian & ubuntu based machines install git-annex correctly

### DIFF
--- a/install/scripts/install.sh
+++ b/install/scripts/install.sh
@@ -20,10 +20,23 @@ git config --global --add user.email  "${email}"
 
 python3 -m pip install --upgrade pip
 
-# Install git annex
-python3 -m pip install datalad-installer
+# Determine OS and install git annex accordingly
+# Runners done on different machines, such as EC2 Runners with Debian, are designed to use apt-get to install git-annex
+# See: https://git-annex.branchable.com/install/
+#
+# DEBIAN_FRONTEND=noninteractive is set to noninteractive in order to avoid an EOF failure due
+# to lack of ability to enter input
+if [ -f "/etc/debian_version" ] || grep -q 'Ubuntu' "/etc/os-release"; then
+    echo "Detected Debian/Ubuntu, installing git-annex using apt-get..."
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt-get update
+    sudo apt-get install -y git-annex
+else
+    echo "Non Debian/Ubuntu system detected, installing git-annex using pip..."
+    python3 -m pip install datalad-installer
+    datalad-installer --sudo ok git-annex
+fi
 
-datalad-installer --sudo ok git-annex
 git config --global filter.annex.process "git-annex filter-process"
 
 # Ensure git annex added to path


### PR DESCRIPTION
Cc @hvgazula 

Relates to https://github.com/neuronets/test-aws/pull/2 & https://github.com/datalad/datalad-action/issues/18

@hvgazula had a GitHub Actions workflow that shifted his workflow onto an external EC2 GPU-powered instance due to memory constraints on the base GitHub Actions Runner. Since the EC2 instance base image was Debian, installation failed. Thus this conditional in this PR would resolve his error